### PR TITLE
Added support for x86 (32-bit)

### DIFF
--- a/example/example.sln
+++ b/example/example.sln
@@ -1,22 +1,37 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example", "example.vcxproj", "{2A702923-DFD2-4569-B6A0-2937CA32415D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|Win32.ActiveCfg = Debug|Win32
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|Win32.Build.0 = Debug|Win32
 		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|x64.ActiveCfg = Debug|x64
 		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|x64.Build.0 = Debug|x64
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|x86.ActiveCfg = Debug|Win32
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Debug|x86.Build.0 = Debug|Win32
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|Win32.ActiveCfg = Release|Win32
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|Win32.Build.0 = Release|Win32
 		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|x64.ActiveCfg = Release|x64
 		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|x64.Build.0 = Release|x64
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|x86.ActiveCfg = Release|Win32
+		{2A702923-DFD2-4569-B6A0-2937CA32415D}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A03931EB-118B-405A-81DE-2E9349317EBE}
 	EndGlobalSection
 EndGlobal

--- a/example/example.vcxproj
+++ b/example/example.vcxproj
@@ -124,6 +124,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <MASM>
+      <UseSafeExceptionHandlers>true</UseSafeExceptionHandlers>
+    </MASM>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>

--- a/longjmp_win64.h
+++ b/longjmp_win64.h
@@ -22,15 +22,44 @@
 #ifndef longjmp_win64_h
 #define longjmp_win64_h
 
-#ifndef _WIN64
-#error longjmp_win64 is an x64 library only.  please check your build configuration.
-#else // _WIN64
-
 #ifdef __cplusplus
 #include <string.h> // for memset function.  not used in C implementation, in which you are responsible for clearing any JMP_BUF_WIN64 yourself if necessary. 
 extern "C"
 {
 #endif // __cplusplus
+
+
+#ifndef _WIN64
+
+	// This struct has room for all of the registers and return addresses that we require.
+	typedef struct _JMP_BUF_WIN64
+	{
+		unsigned long Ebp;
+		unsigned long Ebx;
+		unsigned long Edi;
+		unsigned long Esi;
+		unsigned long Esp;
+		unsigned long Eip;
+		unsigned long RetAddr;
+	
+#ifdef __cplusplus
+		inline _JMP_BUF_WIN64(void)
+		{
+			memset(this, 0, sizeof(_JMP_BUF_WIN64));
+		}
+#endif // __cplusplus
+
+	} JMP_BUF_WIN64[1];
+
+
+	// Analogous to setjmp.
+	int setjmp_win64(JMP_BUF_WIN64 buff);
+
+	// Analogous to longjmp.
+	int longjmp_win64(JMP_BUF_WIN64 buff, int iReturnValue);
+
+
+#else // _WIN64
 
 	// This struct defines the type necessary to store an SE register.
 	typedef struct __declspec(align(16)) JMPBUF_FLOAT128
@@ -88,11 +117,11 @@ extern "C"
 	//   - never actually returns.
 	//   - warning: if you call this with an uninitialized buffer, your program will crash.
 	__int64 longjmp_win64(JMP_BUF_WIN64 buff, __int64 iReturnValue);
-	
+
+#endif // _WIN64
+
 #ifdef __cplusplus
 } // closing the extern "C"
 #endif // __cplusplus
-
-#endif // _WIN64
 
 #endif // longjmp_win64_h


### PR DESCRIPTION
Thank you for making this project available. I needed x86 support so giving back. Some notes:

1. It's a bit confusing with the 32-bit version jmpbuf and functions still called "*_win64" but I didn't want to change names too much.  
2. To build x86 release you might need to add `/safeseh` option to masm build command
3. The x86 version uses `int` return code instead of `__int64`.
4. It's barely tested... kinda seems to work.
5. For my project I need the two functions dllexported and some other tweaks so I'm maintaining a separate copy, but will leave all credits/license in place.

Thanks again
Brad

